### PR TITLE
Fix - Unmarshaling error for Event creation & Feature - Include filtering options for Subscription API

### DIFF
--- a/event.go
+++ b/event.go
@@ -91,34 +91,32 @@ func (e *Event) All(ctx context.Context, query *EventParams) (*ListEventResponse
 	return respPtr, nil
 }
 
-func (e *Event) Create(ctx context.Context, body *CreateEventRequest) (*EventResponse, error) {
+func (e *Event) Create(ctx context.Context, body *CreateEventRequest) error {
 	url, err := addOptions(e.generateUrl(), nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	respPtr := &EventResponse{}
-	err = postJSON(ctx, e.client, url, body, respPtr)
+	err = postJSON(ctx, e.client, url, body, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return respPtr, nil
+	return nil
 }
 
-func (e *Event) FanoutEvent(ctx context.Context, body *CreateFanoutEventRequest) (*EventResponse, error) {
+func (e *Event) FanoutEvent(ctx context.Context, body *CreateFanoutEventRequest) error {
 	url, err := addOptions(e.generateUrl()+"/fanout", nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	respPtr := &EventResponse{}
-	err = postJSON(ctx, e.client, url, body, respPtr)
+	err = postJSON(ctx, e.client, url, body, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return respPtr, nil
+	return nil
 }
 
 func (e *Event) Find(ctx context.Context, eventID string) (*EventResponse, error) {

--- a/subscription.go
+++ b/subscription.go
@@ -37,8 +37,14 @@ type RetryConfiguration struct {
 	RetryCount int    `json:"retry_count"`
 }
 
+type Filter struct {
+	Body    map[string]interface{} `json:"body"`
+	Headers map[string]interface{} `json:"headers"`
+}
+
 type FilterConfiguration struct {
 	EventTypes []string `json:"event_types" bson:"event_types,omitempty"`
+	Filter     Filter   `json:"filter" bson:"filter,omitempty"`
 }
 
 type SubscriptionResponse struct {


### PR DESCRIPTION
Fixed the marshaling error which was occuring when a single event or a fanout event was created. The issue was occurring due to the fact that the APIResponse from these two endpoints results in a null value being returned for the data field. This resulted in an unmarshaling error in the parseAPIResponse function.