### PR TITLE
Lilsahil/feature/endpoint metadata

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -53,7 +53,8 @@ type SubscriptionResponse struct {
 	Type   string `json:"type"`
 	Status string `json:"status"`
 
-	Source *SourceResponse `json:"source_metadata,omitempty"`
+	Source           *SourceResponse   `json:"source_metadata,omitempty"`
+	EndpointMetaData *EndpointResponse `json:"endpoint_metadata"`
 
 	// subscription config
 	AlertConfig  *AlertConfiguration  `json:"alert_config,omitempty"`

--- a/subscription.go
+++ b/subscription.go
@@ -37,8 +37,14 @@ type RetryConfiguration struct {
 	RetryCount int    `json:"retry_count"`
 }
 
+type Filter struct {
+	Body    map[string]interface{} `json:"body"`
+	Headers map[string]interface{} `json:"headers"`
+}
+
 type FilterConfiguration struct {
 	EventTypes []string `json:"event_types" bson:"event_types,omitempty"`
+	Filter     Filter   `json:"filter" bson:"filter,omitempty"`
 }
 
 type SubscriptionResponse struct {


### PR DESCRIPTION
Feature: Added endpoint_metadata information to the response struct for 'all' subscription endpoint. Created customString type to handle JSON values that can be either strings or integers. The api response sometimes returns a string or an integer depending on the endpoint that is being hit, so setting the type to a simple int does not resolve the issue - as it will break for other endpoints.
- Introduced customString type to manage JSON values that may be strings or integers.
- Implemented custom UnmarshalJSON and MarshalJSON methods for customString.
- Updated EndpointResponse struct to use customString for fields requiring flexible JSON handling.

Fixes #46 