### PR TITLE
feat: align sdk with current convoy api

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ To begin you need to define a Client.
 Below are the several ways you can configure a client depending on your needs. 
 
 ```go
-baseURL := "{host}/api/v1"
+// Convoy Cloud (US): https://us.getconvoy.cloud/api/v1
+// Convoy Cloud (EU): https://eu.getconvoy.cloud/api/v1
+// Self-hosted: https://your-instance/api/v1
+baseURL := "https://us.getconvoy.cloud/api/v1"
 
 // Regular Client
 c := convoy.New(baseURL, apiKey, projectID)
@@ -45,9 +48,9 @@ Please see [go reference](https://pkg.go.dev/github.com/frain-dev/convoy-go) for
 ```go
 body := &convoy.CreateEndpointRequest{
     Name: "endpoint-name",
-    URL: "http://play.getconvoy.io/ingest/DQzxCcNKTB7SGqzm",
+    URL: "https://example.com/webhooks/convoy",
     Secret: "endpoint-secret",
-    SupportEmail: "notifications@getconvoy.io"
+    SupportEmail: "notifications@getconvoy.io",
 }
 
 endpoint, err := c.Endpoints.Create(ctx, body, nil)
@@ -140,19 +143,29 @@ if err != nil {
 ```
 
 ### Verifying Webhooks
-This client supports verifying [simple](https://www.getconvoy.io/docs/manual/signatures#Simple%20signatures) and [advanced](https://www.getconvoy.io/docs/manual/signatures#Advanced%20signatures) webhook signatures. 
+This client supports verifying [simple](https://www.getconvoy.io/docs/manual/signatures#Simple%20signatures) and [advanced](https://www.getconvoy.io/docs/manual/signatures#Advanced%20signatures) webhook signatures. Verify with the raw request body, before parsing it.
+
 ```go 
-webhook := NewWebhook(&convoy.ConfigOpts{
-    SigHeader: "ZmBgy+E0i7x+yY9Ok92P3CZQkc+FEJgR5gYZ0bwSEhwLESnc/gGct57IQ==",
-    Payload:   []byte(`{"firstname":"test","lastname":"test"}`),
-    Secret:    "8IX9njirDG",
-    Hash:      "SHA512",
-    Encoding:  "base64",
+webhook := convoy.NewWebhook(&convoy.WebhookOpts{
+    Secret: "endpoint-secret",
 })
 
-err := webhook.Verify()
-if err != nil {
-    return err 
+// Verify an incoming *http.Request. This reads the request body; read it
+// yourself first and use VerifyPayload if you need the body afterwards.
+func handler(w http.ResponseWriter, r *http.Request) {
+    body, err := io.ReadAll(r.Body)
+    if err != nil {
+        http.Error(w, "failed to read body", http.StatusBadRequest)
+        return
+    }
+
+    if err := webhook.VerifyPayload(body, r.Header.Get("X-Convoy-Signature")); err != nil {
+        http.Error(w, "invalid signature", http.StatusBadRequest)
+        return
+    }
+
+    // signature is valid; process the event using body
+    w.WriteHeader(http.StatusOK)
 }
 ```
 
@@ -164,6 +177,7 @@ The following table identifies which version of the Convoy API is supported by t
 | v2.1.5            | 0001-01-01         |
 | v2.1.6            | 0001-01-01         |
 | v2.1.7            | 0001-01-01         |
+| v2.2.0            | 2025-11-24         |
 
 ## Credits
 - [Frain](https://github.com/frain-dev)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Please see [go reference](https://pkg.go.dev/github.com/frain-dev/convoy-go) for
 ```go
 body := &convoy.CreateEndpointRequest{
     Name: "endpoint-name",
-    URL: "https://example.com/webhooks/convoy",
+    // Grab your own ingest URL from https://playground.getconvoy.io
+    URL: "https://us.getconvoy.cloud/ingest/DQzxCcNKTB7SGqzm",
     Secret: "endpoint-secret",
     SupportEmail: "notifications@getconvoy.io",
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Please see [go reference](https://pkg.go.dev/github.com/frain-dev/convoy-go) for
 ```go
 body := &convoy.CreateEndpointRequest{
     Name: "endpoint-name",
-    // Grab your own ingest URL from https://playground.getconvoy.io
+    // Get a test ingest URL from https://playground.getconvoy.io
     URL: "https://us.getconvoy.cloud/ingest/DQzxCcNKTB7SGqzm",
     Secret: "endpoint-secret",
     SupportEmail: "notifications@getconvoy.io",

--- a/endpoint.go
+++ b/endpoint.go
@@ -18,9 +18,9 @@ type Endpoint struct {
 
 type CreateEndpointRequest struct {
 	Name               string `json:"name"`
-	SupportEmail       string `json:"support_email"`
-	OwnerID            string `json:"owner_id"`
-	SlackWebhookUrl    string `json:"slack_webhook_url"`
+	SupportEmail       string `json:"support_email,omitempty"`
+	OwnerID            string `json:"owner_id,omitempty"`
+	SlackWebhookUrl    string `json:"slack_webhook_url,omitempty"`
 	URL                string `json:"url"`
 	Secret             string `json:"secret,omitempty"`
 	Description        string `json:"description,omitempty"`
@@ -28,19 +28,21 @@ type CreateEndpointRequest struct {
 	IsDisabled         bool   `json:"is_disabled"`
 	ContentType        string `json:"content_type,omitempty"`
 
-	Authentication *EndpointAuth `json:"authentication"`
+	Authentication *EndpointAuth `json:"authentication,omitempty"`
 
-	HttpTimeout       string `json:"http_timeout,omitempty"`
-	RateLimit         int    `json:"rate_limit,omitempty"`
-	RateLimitDuration string `json:"rate_limit_duration,omitempty"`
+	// HttpTimeout is the endpoint request timeout in seconds.
+	HttpTimeout uint64 `json:"http_timeout,omitempty"`
+	RateLimit   int    `json:"rate_limit,omitempty"`
+	// RateLimitDuration is the rate limit window in seconds.
+	RateLimitDuration uint64 `json:"rate_limit_duration,omitempty"`
 }
 
 type EndpointResponse struct {
 	UID         string `json:"uid"`
-	GroupID     string `json:"group_id"`
+	ProjectID   string `json:"project_id"`
 	OwnerID     string `json:"owner_id"`
-	TargetUrl   string `json:"target_url"`
-	Title       string `json:"title"`
+	URL         string `json:"url"`
+	Name        string `json:"name"`
 	Description string `json:"description"`
 
 	Status             string   `json:"status"`
@@ -48,15 +50,23 @@ type EndpointResponse struct {
 	AdvancedSignatures bool     `json:"advanced_signatures"`
 	SlackWebhookUrl    string   `json:"slack_webhook_url"`
 	SupportEmail       string   `json:"support_email"`
-	IsDisabled         bool     `json:"is_disabled"`
 	ContentType        string   `json:"content_type"`
 
-	HttpTimeout       string `json:"http_timeout"`
-	RateLimit         int    `json:"rate_limit"`
-	RateLimitDuration string `json:"rate_limit_duration"`
+	// HttpTimeout is the endpoint request timeout in seconds.
+	HttpTimeout uint64 `json:"http_timeout"`
+	RateLimit   int    `json:"rate_limit"`
+	// RateLimitDuration is the rate limit window in seconds.
+	RateLimitDuration uint64 `json:"rate_limit_duration"`
 
 	Authentication *EndpointAuth `json:"authentication"`
 	Events         int64         `json:"events"`
+
+	// FailureRate is the circuit breaker's rolling failure rate; null when the
+	// feature is off or has no sample for this endpoint.
+	FailureRate *float64 `json:"failure_rate"`
+	// CBState is the circuit breaker state ("open", "half-open", "closed");
+	// null when off/unlicensed or unsampled.
+	CBState *string `json:"cb_state"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/event_delivery.go
+++ b/event_delivery.go
@@ -117,6 +117,8 @@ func (e *EventDelivery) Resend(ctx context.Context, eventDeliveryID string, quer
 	return respPtr, nil
 }
 
+// BatchResend retries deliveries matching the query filters; the server reads
+// filters from query params only.
 func (e *EventDelivery) BatchResend(ctx context.Context, query *EventDeliveryParams) error {
 	url, err := addOptions(e.generateUrl()+"/batchretry", query)
 	if err != nil {
@@ -124,7 +126,7 @@ func (e *EventDelivery) BatchResend(ctx context.Context, query *EventDeliveryPar
 	}
 
 	respPtr := &EventDeliveryResponse{}
-	err = putResource(ctx, e.client, url, nil, respPtr)
+	err = postJSON(ctx, e.client, url, struct{}{}, respPtr)
 	if err != nil {
 		return err
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -75,7 +75,7 @@ func createEndpoint(ctx context.Context, c *convoy.Client) string {
 		Description:        "Some description",
 		OwnerID:            "my_owner_id",
 		AdvancedSignatures: &tr,
-		HttpTimeout:        "10s",
+		HttpTimeout:        10,
 	}, nil)
 
 	if err != nil {

--- a/request.go
+++ b/request.go
@@ -64,20 +64,24 @@ func deleteResource(ctx context.Context, c *Client, url string, res interface{})
 func doReq(c *Client, req *http.Request, res interface{}) error {
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
-	req.Header.Set("X-Convoy-Version", "0001-01-01")
+	// Pin the current API version so request/response migrations are a no-op.
+	// Older pins (e.g. 0001-01-01) make the server rewrite http_timeout and
+	// rate_limit_duration into legacy duration strings.
+	req.Header.Set("X-Convoy-Version", "2025-11-24")
 
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("error processing request - %+v", err)
-	}
-
-	// Send debug logs.
+	// Dump before sending; afterwards the body is already consumed and the
+	// dump fails with a spurious error log on every request.
 	dump, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		c.log.Errorf("error dumping request payload - ", err)
 	}
 
 	c.log.Debugf("request: %q", dump)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error processing request - %+v", err)
+	}
 
 	err = parseAPIResponse(c, resp, res)
 	if err != nil {
@@ -119,7 +123,9 @@ func parseAPIResponse(c *Client, resp *http.Response, resultPtr interface{}) err
 		return fmt.Errorf("convoy error: %s", response.Message)
 	}
 
-	if resultPtr != nil {
+	// Data is null for accepted-async endpoints (e.g. batchretry), so only
+	// unmarshal when the server actually sent a payload.
+	if resultPtr != nil && response.Data != nil {
 		err = json.Unmarshal(*response.Data, resultPtr)
 		if err != nil {
 			return fmt.Errorf("error while unmarshalling the response data bytes %+v ", err)

--- a/request.go
+++ b/request.go
@@ -70,11 +70,16 @@ func doReq(c *Client, req *http.Request, res interface{}) error {
 	req.Header.Set("X-Convoy-Version", "2025-11-24")
 
 	// Dump before sending; afterwards the body is already consumed and the
-	// dump fails with a spurious error log on every request.
+	// dump fails with a spurious error log on every request. Redact the
+	// credential first so debug logs shipped to shared observability
+	// systems never contain the API key.
+	auth := req.Header.Get("Authorization")
+	req.Header.Set("Authorization", "Bearer [REDACTED]")
 	dump, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		c.log.Errorf("error dumping request payload - ", err)
 	}
+	req.Header.Set("Authorization", auth)
 
 	c.log.Debugf("request: %q", dump)
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -1,0 +1,98 @@
+package convoy_go
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type capturedRequest struct {
+	method string
+	path   string
+	query  string
+	body   string
+	header http.Header
+}
+
+func newTestClient(t *testing.T, respBody string) (*Client, *capturedRequest) {
+	t.Helper()
+
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.query = r.URL.RawQuery
+		captured.body = string(body)
+		captured.header = r.Header.Clone()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(respBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	return New(srv.URL, "test-api-key", "test-project-id"), captured
+}
+
+func TestBatchResendPostsEmptyBodyWithQueryFilters(t *testing.T) {
+	c, captured := newTestClient(t, `{"status":true,"message":"Batch retry processing","data":null}`)
+
+	err := c.EventDeliveries.BatchResend(context.Background(), &EventDeliveryParams{Status: []string{"Failure"}})
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodPost, captured.method)
+	require.Equal(t, "/projects/test-project-id/eventdeliveries/batchretry", captured.path)
+	require.Contains(t, captured.query, "status=Failure")
+	require.JSONEq(t, `{}`, captured.body)
+}
+
+func TestBatchResendHandlesNullDataResponse(t *testing.T) {
+	// Accepted-async endpoints return data: null; the client must not panic.
+	c, _ := newTestClient(t, `{"status":true,"message":"Batch retry processing","data":null}`)
+
+	require.NotPanics(t, func() {
+		err := c.EventDeliveries.BatchResend(context.Background(), nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestRequestsPinConvoyVersionAndAuthHeaders(t *testing.T) {
+	c, captured := newTestClient(t, `{"status":true,"message":"ok","data":{"content":[],"pagination":{}}}`)
+
+	_, err := c.EventDeliveries.All(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "Bearer test-api-key", captured.header.Get("Authorization"))
+	require.Equal(t, "2025-11-24", captured.header.Get("X-Convoy-Version"))
+}
+
+func TestEndpointPauseUsesPut(t *testing.T) {
+	c, captured := newTestClient(t, `{"status":true,"message":"endpoint paused","data":{"uid":"ep-1"}}`)
+
+	_, err := c.Endpoints.Pause(context.Background(), "ep-1")
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodPut, captured.method)
+	require.Equal(t, "/projects/test-project-id/endpoints/ep-1/pause", captured.path)
+}
+
+func TestEventCreatePostsToEvents(t *testing.T) {
+	c, captured := newTestClient(t, `{"status":true,"message":"Event queued successfully","data":null}`)
+
+	err := c.Events.Create(context.Background(), &CreateEventRequest{
+		EndpointID: "ep-1",
+		EventType:  "test.event",
+		Data:       []byte(`{"k":"v"}`),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodPost, captured.method)
+	require.Equal(t, "/projects/test-project-id/events", captured.path)
+	require.Contains(t, captured.body, `"endpoint_id":"ep-1"`)
+}

--- a/routes_test.go
+++ b/routes_test.go
@@ -2,9 +2,11 @@ package convoy_go
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -70,6 +72,43 @@ func TestRequestsPinConvoyVersionAndAuthHeaders(t *testing.T) {
 
 	require.Equal(t, "Bearer test-api-key", captured.header.Get("Authorization"))
 	require.Equal(t, "2025-11-24", captured.header.Get("X-Convoy-Version"))
+}
+
+type captureLogger struct {
+	debug strings.Builder
+}
+
+func (l *captureLogger) Debugf(format string, v ...interface{}) {
+	l.debug.WriteString(fmt.Sprintf(format, v...))
+}
+func (l *captureLogger) Errorf(string, ...interface{}) {}
+func (l *captureLogger) Infof(string, ...interface{})  {}
+func (l *captureLogger) Warnf(string, ...interface{})  {}
+
+func TestDebugDumpRedactsAPIKeyButSendsRealCredential(t *testing.T) {
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.header = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":true,"message":"ok","data":null}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := &captureLogger{}
+	c := New(srv.URL, "test-api-key", "test-project-id", OptionLogger(logger))
+
+	err := c.Events.Create(context.Background(), &CreateEventRequest{
+		EndpointID: "ep-1",
+		EventType:  "test.event",
+		Data:       []byte(`{"k":"v"}`),
+	})
+	require.NoError(t, err)
+
+	// The debug dump must never contain the credential, but the wire
+	// request must still carry it.
+	require.NotContains(t, logger.debug.String(), "test-api-key")
+	require.Contains(t, logger.debug.String(), "Bearer [REDACTED]")
+	require.Equal(t, "Bearer test-api-key", captured.header.Get("Authorization"))
 }
 
 func TestEndpointPauseUsesPut(t *testing.T) {

--- a/source.go
+++ b/source.go
@@ -26,7 +26,7 @@ type CreateSourceRequest struct {
 
 type SourceResponse struct {
 	UID            string          `json:"uid"`
-	GroupID        string          `json:"group_id"`
+	ProjectID      string          `json:"project_id"`
 	MaskID         string          `json:"mask_id"`
 	Name           string          `json:"name"`
 	Type           string          `json:"type"`


### PR DESCRIPTION
## Summary

- Updates endpoint request/response structs to the current schema (`uint64` for `http_timeout`/`rate_limit_duration`, current response fields) and renames source `GroupID` to `ProjectID`.
- `BatchResend` now POSTs with an empty body per the server contract (was PUT); filters go in query params.
- Pins `X-Convoy-Version` to `2025-11-24`: without the pin the server assumes the oldest API version and down-migrates responses (e.g. `http_timeout` as a duration string), breaking the numeric struct fields.
- Fixes a nil-pointer dereference in `parseAPIResponse` when accepted-async endpoints return `data: null` (e.g. `batchretry`), and moves the debug request dump before the request executes so it no longer consumes the body and logs an error on every request.
- README updated: current client config, corrected webhook verification example using `NewWebhook`/`VerifyPayload`.

## Test plan

- [x] `go vet ./...` clean, `go test ./...` (21 tests incl. new httptest route contracts: methods, paths, empty bodies, `data: null` handling, auth/version headers)
- [x] Live smoke against a licensed QA instance: all routes (project, endpoint lifecycle, subscription, events, deliveries) pass
- [x] Edge matrix: bad key, invalid body, 404s, unreachable host, malformed signature headers; typed errors, no panics
- [x] Delivered payload parity and signature verification against a real delivery captured from a webhook sink

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking JSON field renames and numeric timeout types can break existing callers; BatchResend HTTP method change and version pinning alter runtime API behavior across the SDK.
> 
> **Overview**
> Brings **convoy-go** in line with the current Convoy API (**`2025-11-24`**, documented for **v2.2.0**).
> 
> **Models and breaking shape changes:** Endpoint request/response fields now match the server (`url`/`name`, `project_id`, `http_timeout` and `rate_limit_duration` as **seconds as `uint64`**, optional circuit-breaker `failure_rate` / `cb_state`). Source responses use `project_id` instead of `group_id`. Several JSON tags gain `omitempty` on optional fields.
> 
> **HTTP client behavior:** Every request sends **`X-Convoy-Version: 2025-11-24`** so the server does not down-migrate timeouts into legacy duration strings. **`EventDeliveries.BatchResend`** is **POST** with **`{}`** and filters in query params (was PUT). **`parseAPIResponse`** skips unmarshaling when **`data` is null** (async accepts like batch retry). Debug request dumps run **before** the wire send, with **Authorization redacted** in logs.
> 
> **Docs and tests:** README uses current cloud base URLs and a **`NewWebhook` / `VerifyPayload`** verification example. New **httptest** coverage locks batch retry, version/auth headers, redacted debug dumps, and key routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110f4f8006d563339ed7fffb316caf525893a36a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->