### PR TITLE
feat: regenerate API client from OpenAPI spec

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -1515,7 +1515,8 @@ type ModelsCreateEvent struct {
 	// webhook to the endpoints
 	Data *map[string]interface{} `json:"data,omitempty"`
 
-	// EndpointId Specifies the endpoint to send this event to.
+	// EndpointId Specifies the endpoint to send this event to. Required unless the
+	// deprecated app_id is provided.
 	EndpointId *string `json:"endpoint_id,omitempty"`
 
 	// EventType Event Type is used for filtering and debugging e.g invoice.paid


### PR DESCRIPTION
Automated regeneration via oapi-codegen from `docs/v3/openapi3.yaml` on frain-dev/convoy main. The hand-written root package and webhook verify are untouched by the sync script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change on a generated model; no logic or API behavior changes in this diff.
> 
> **Overview**
> Regenerated **`client/client.gen.go`** from the OpenAPI spec. The only visible change in this sync is clearer godoc on **`ModelsCreateEvent.EndpointId`**: it now states the field is **required unless the deprecated `app_id` is provided**, aligning generated client docs with the API contract.
> 
> No hand-written client code or runtime behavior changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72c9681ffc03c45c279ec54b9acbc1020c6abd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->